### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 ---
 
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gostevedore/stevedore/security/code-scanning/4](https://github.com/gostevedore/stevedore/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the jobs primarily involve checking out the repository and running tests, which typically require `contents: read` permission. No write permissions are necessary unless explicitly stated.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This ensures consistency and avoids redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
